### PR TITLE
subscribe to more events + implement gtm requested recording filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ From [git-time-metric/gtm](https://github.com/git-time-metric/gtm)
 >GTM is automatic, seamless and lightweight. There is no need to remember to start and stop timers. It's a process that only runs on occasion to capture edit events triggered by the editor. It does not require a background process or any file system monitoring.
 >Your time metrics are stored locally with the repository as Git notes. If you want to share your data, it can be pushed and fetched to and from the remote repository. Other GTM users on your team can do the same. This provides you the ability to see time metrics for the entire team.
 ## Features
-- auto updates gtm everytime a file is saved
+- auto updates gtm everytime a file is saved + changed
 
 ## Requirements
 
@@ -27,9 +27,14 @@ only tested on Ubuntu, so may not work on OSX, other Linuxs, and/or Windows
 
 ## Release Notes
 
+### 0.0.2
+
+Improved reporting logic to factor in changing current text file
+
 ### 0.0.1
 
 Initial release of vscode-gtm
+
 
 
 ### Notes

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-gtm",
     "displayName": "vscode-gtm",
     "description": "VSCode plugin to support Git Time Metrics",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "publisher": "s3ramsay",
     "license": "MIT",
     "engines": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ function run_cmd(cmd, args, callBack) {
   var resp = "";
   child.on('error', function (code) { console.error('error', resp); callBack(code) });
   child.stdout.on('data', function (buffer) { resp += buffer.toString() });
-  child.on('close', function (code) { callBack(code) });
+  child.on('close', function (code) {console.log(resp) ;callBack(code) });
 }
 
 export function activate(context: vscode.ExtensionContext) {
@@ -19,10 +19,29 @@ export function activate(context: vscode.ExtensionContext) {
   });
   let subscriptions: vscode.Disposable[] = [];
 
-  // report time every time a file is saved
-  vscode.workspace.onDidSaveTextDocument((e: vscode.TextDocument) => {
-    run_cmd('gtm', ['record', e.fileName], (res) => console.log(res));
-  }, this, subscriptions);
+
+  let lastUpdated: Date = new Date();
+  let lastSavedFileName: string;
+  const MIN_UPDATE_FREQUENCE_MS = 30000; // 30 seconds
+
+  function handleUpdateEvent(fileName: string){
+    const now = new Date();
+    // if a new file is being saved OR it have been at least MIN_UPDATE_FREQUENCE_MS, record it
+    if (fileName !== lastSavedFileName || (now.getTime() - lastUpdated.getTime()) >= MIN_UPDATE_FREQUENCE_MS) {
+      run_cmd('gtm', ['record', lastSavedFileName], () => { });
+      lastSavedFileName = fileName;
+      lastUpdated = now;
+    }
+  }
+
+  // report to gtm everytime a file is saved
+  vscode.workspace.onDidSaveTextDocument((e: vscode.TextDocument) => handleUpdateEvent(e.fileName), this, subscriptions);
+
+  // report to gtm everytime the user's selection of text changes
+  vscode.window.onDidChangeTextEditorSelection((e:vscode.TextEditorSelectionChangeEvent) => handleUpdateEvent(e.textEditor.document.fileName), this, subscriptions);
+
+  // report  to gtm everytime the user switches textEditors
+  vscode.window.onDidChangeActiveTextEditor((e:vscode.TextEditor) => handleUpdateEvent(e.document.fileName), this, subscriptions);
 }
 
 // always active, so no need to deactivate


### PR DESCRIPTION
- only record file change with gtm if the filename changed OR if it has been more than 30 seconds since the last update
- subscribe to vscode.window.onDidChangeTextEditorSelection and vscode.window.onDidChangeActiveTextEditor
- bumped version to 0.0.2