### PR TITLE
Use gtm verify, update to gtm version 1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-gtm",
     "displayName": "vscode-gtm",
     "description": "VSCode plugin to support Git Time Metrics",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "publisher": "s3ramsay",
     "license": "MIT",
     "engines": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,7 +29,7 @@ export function activate(context: vscode.ExtensionContext) {
          vscode.window.showWarningMessage('Installed gtm version is below v1.2.1. Please update your gtm installation.');
        }
     }, (res: Result) => {
-      if (res.code != 0) {
+      if (res.code < 0) {
         vscode.window.showErrorMessage('gtm is not available on your $PATH. please install it first');
       }
     });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,16 +21,15 @@ function run_cmd(cmd: string, args: string[]): Promise<Result> {
     child.on('close', (code: number) => resolve(<Result>{ code, output }));
   });
 }
-
 export function activate(context: vscode.ExtensionContext) {
   // check if gtm is installed + available
-  run_cmd('gtm', ['-v'])
+  run_cmd('gtm', ['verify', '1.2.1'])
     .then((res: Result) => {
-      if(res.output < 'v1.0.0'){
-         vscode.window.showWarningMessage('Installed gtm version is below v1.0.0. Please update your gtm installation.');
+      if(res.output != 'true'){
+         vscode.window.showWarningMessage('Installed gtm version is below v1.2.1. Please update your gtm installation.');
        }
     }, (res: Result) => {
-      if (res.code < 0) {
+      if (res.code != 0) {
         vscode.window.showErrorMessage('gtm is not available on your $PATH. please install it first');
       }
     });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,7 +23,7 @@ function run_cmd(cmd: string, args: string[]): Promise<Result> {
 }
 export function activate(context: vscode.ExtensionContext) {
   // check if gtm is installed + available
-  run_cmd('gtm', ['verify', '1.2.1'])
+  run_cmd('gtm', ['verify', '>= 1.2.1'])
     .then((res: Result) => {
       if(res.output != 'true'){
          vscode.window.showWarningMessage('Installed gtm version is below v1.2.1. Please update your gtm installation.');


### PR DESCRIPTION
Update version check to use `gtm verify` instead of `gtm -v`.  This command is used to verify the version constraint.  We've also released version `1.2.1` of gtm.